### PR TITLE
drawPixel() fixed to match Adafruit_GFX

### DIFF
--- a/Sketches/libraries/EPD_GFX/EPD_GFX.h
+++ b/Sketches/libraries/EPD_GFX/EPD_GFX.h
@@ -52,7 +52,7 @@ public:
 	void end();
 
 	// set a single pixel in new_image
-	void drawPixel(int x, int y, unsigned int colour) {
+	void drawPixel(int16_t x, int16_t y, uint16_t colour) {
 		int bit = x & 0x07;
 		int byte = x / 8 + y * (pixel_width / 8);
 		int mask = 0x01 << bit;


### PR DESCRIPTION
Using the latest version of Adafruit_GFX, the method signature of the implementation of drawPixel() in EPD_GFX.h does not match the virtual method signature of drawPixel() in Adafruit_GFX.h. This results in compile time errors about the drawPixel() method not being implemented. I copied the signature from Adafruit_GFX.h into EPD_GFX.h and confirmed that everything compiled and ran properly.
