### PR TITLE
LaunchPad MSP430F5529, CC3200 and MSP432

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # gratis
 
+Updated 2015-08-01 by Rei Vilo
+
+* Added `#include Energia.h`
+* For Energia, changed pin names to pin numbers (pin names are deprecated)
+* Works on MSP430F5529, LM4F120, TM4C123
+* Fails on MSP432 and CC3200
+* [Recognize the FPL material type by the rear labels](http://www.pervasivedisplays.com/products/label_info)
+* Use branch [rei-vilo / gratis / CC3200 and MSP432](https://github.com/rei-vilo/gratis/tree/CC3200-and-MSP432)
+
+
 ## Sketches
 
 These are example programs that will compile and run on the following platforms

--- a/Sketches/demo/demo.ino
+++ b/Sketches/demo/demo.ino
@@ -13,6 +13,11 @@
 // express or implied.  See the License for the specific language
 // governing permissions and limitations under the License.
 
+// Updated 2015-08-01 by Rei Vilo
+// . Added #include Energia
+// . For Energia, changed pin names to pin numbers (see comment below)
+// . Works on MSP430F5529, LM4F120, TM4C123
+// . Fails on MSP432 and CC3200
 
 // {% SYSTEM:notice %}
 
@@ -33,7 +38,12 @@
 // * back to text display
 
 
-#include <Arduino.h>
+#if defined(ENERGIA)
+#   include "Energia.h"
+#else
+#   include <Arduino.h>
+#endif
+
 #include <inttypes.h>
 #include <ctype.h>
 
@@ -50,7 +60,7 @@
 #define IMAGE_2  cat
 
 // Error message for MSP430
-#if (SCREEN_SIZE == 270) && defined(__MSP430_CPU__)
+#if (SCREEN_SIZE == 270) && defined(__MSP430G2553__)
 #error MSP430: not enough memory
 #endif
 
@@ -97,22 +107,71 @@ PROGMEM const
 #undef unsigned
 
 
-#if defined(__MSP430_CPU__)
+#if defined(ENERGIA)
 
-// TI LaunchPad IO layout
-const int Pin_TEMPERATURE = A4;
-const int Pin_PANEL_ON = P2_3;
-const int Pin_BORDER = P2_5;
-const int Pin_DISCHARGE = P2_4;
+// For Energia, use pin numbers instead of pin names.
+// * pin names are going to be deprecated
+// * pin numbers ensure consistency across all LaunchPads
+
+const int Pin_TEMPERATURE   = 6;  //  A10 = MSP432,   A6 = F5529, MSP430 = A4;
+const int Pin_PANEL_ON      = 11; // P3_6 = MSP432, P8_1 = F5529, MSP430 = P2_3;
+const int Pin_BORDER        = 13; // P5_0 = MSP432, P2_6 = F5529, MSP430 = P2_5;
+const int Pin_DISCHARGE     = 12; // P5_2 = MSP432, P2_3 = F5529, MSP430 = P2_4;
+
+const int Pin_RESET         = 10; // P6_4 = MSP432, P4_1 = F5529, MSP430 = P2_2;
+const int Pin_BUSY          = 8;  // P4_6 = MSP432, P2_7 = F5529, MSP430 = P2_0;
+const int Pin_EPD_CS        = 19; // P2_5 = MSP432, P2_0 = F5529, MSP430 = P2_6;
+const int Pin_EPD_FLASH_CS  = 18; // P3_0 = MSP432, P2_2 = F5529, MSP430 = P2_7;
+
+const int Pin_SW2           = PUSH2; // PUSH2 = MSP432, PUSH2 = F5529, MSP430 = PUSH2;
+const int Pin_RED_LED       = RED_LED; // RED_LED = MSP432, RED_LED = F5529, MSP430 = RED_LED;
+
+#   if defined(__MSP430G2553__)
+// MSP430G2553 LaunchPad IO layout
+
 #if EPD_PWM_REQUIRED
-const int Pin_PWM = P2_1;
+const int Pin_PWM           = 9; // P6_5 = MSP432, P4_2_PWM = F5529, MSP430 = P2_1;
 #endif
-const int Pin_RESET = P2_2;
-const int Pin_BUSY = P2_0;
-const int Pin_EPD_CS = P2_6;
-const int Pin_EPD_FLASH_CS = P2_7;
-const int Pin_SW2 = P1_3;
-const int Pin_RED_LED = P1_0;
+
+#   elif defined(__MSP430F5529__)
+
+// __MSP430F5529__
+// MSP430F5529 LaunchPad IO layout
+// Pin_PWM requires a special macro P4_2_PWM
+//
+#if EPD_PWM_REQUIRED
+// Simulated PWM on port P4_2 linked to port P7_4
+// See http://forum.43oh.com/topic/4372-solved-help-software-pwm-for-the-msp430f5529/?p=39372
+// Posted 17 September 2013 - 09:53 PM by energia
+//
+#define PM_P42_SET_MODE ((PM_TB0CCR2A << 8) | PORT_SELECTION0 | OUTPUT)
+#define P4_2_PWM P7_4
+const int Pin_PWM           = P4_2_PWM; // = F5529, MSP430 = P2_1;
+#endif
+
+#   elif defined(__LM4F120H5QR__)
+
+#if EPD_PWM_REQUIRED
+const int Pin_PWM           = 9; // P6_5 = MSP432, P4_2_PWM = F5529, MSP430 = P2_1;
+#endif
+
+#   elif defined(__CC3200R1M1RGC__)
+
+#if EPD_PWM_REQUIRED
+const int Pin_PWM           = 9; // P6_5 = MSP432, P4_2_PWM = F5529, MSP430 = P2_1;
+#endif
+
+#   elif defined(__MSP432P401R__)
+// MSP432P401R LaunchPad IO layout
+// Pin_PWM requires a dedicated timer task
+//
+#if EPD_PWM_REQUIRED
+#error No PWM on pin 9 for MSP432
+#endif
+
+#   else
+#       error LaunchPad for Energia not supported
+#   endif
 
 #else
 
@@ -154,7 +213,8 @@ EPD_Class EPD(EPD_SIZE,
 
 
 // I/O setup
-void setup() {
+void setup()
+{
 	pinMode(Pin_RED_LED, OUTPUT);
 	pinMode(Pin_SW2, INPUT);
 	pinMode(Pin_TEMPERATURE, INPUT);
@@ -181,25 +241,33 @@ void setup() {
 	digitalWrite(Pin_EPD_FLASH_CS, HIGH);
 
 	Serial.begin(9600);
+    delay(500);
+    
 #if defined(__AVR__)
 	// wait for USB CDC serial port to connect.  Arduino Leonardo only
-	while (!Serial) {
-	}
+    while (!Serial);
 	delay(20);  // allows terminal time to sync
 #endif
+    
 	Serial.println();
 	Serial.println();
 	Serial.println("Demo version: " DEMO_VERSION);
 	Serial.println("Display size: " MAKE_STRING(EPD_SIZE));
 	Serial.println("Film: V" MAKE_STRING(EPD_FILM_VERSION));
 	Serial.println("COG: G" MAKE_STRING(EPD_CHIP_VERSION));
-
+    Serial.println();
+    
+    Serial.println("Image 1: " IMAGE_1_FILE);
+    Serial.println("Image 2: " IMAGE_2_FILE);
 	Serial.println();
 
 	EPD_FLASH.begin(Pin_EPD_FLASH_CS);
-	if (EPD_FLASH.available()) {
+    if (EPD_FLASH.available())
+    {
 		Serial.println("EPD FLASH chip detected OK");
-	} else {
+    }
+    else
+    {
 		uint8_t maufacturer;
 		uint16_t device;
 		EPD_FLASH.info(&maufacturer, &device);
@@ -219,17 +287,19 @@ static int state = 0;
 
 
 // main loop
-void loop() {
+void loop()
+{
 	int temperature = S5813A.read();
 	Serial.print("Temperature = ");
-	Serial.print(temperature);
-	Serial.println(" Celcius");
+    Serial.print(temperature, DEC);
+    Serial.println(" Celsius");
 
 	EPD.begin(); // power up the EPD panel
 	EPD.setFactor(temperature); // adjust for current temperature
 
 	int delay_counts = 50;
-	switch(state) {
+    switch(state)
+    {
 	default:
 	case 0:         // clear the screen
 		EPD.clear();
@@ -273,7 +343,8 @@ void loop() {
 	EPD.end();   // power down the EPD panel
 
 	// flash LED for 5 seconds
-	for (int x = 0; x < delay_counts; ++x) {
+    for (int x = 0; x < delay_counts; ++x)
+    {
 		digitalWrite(Pin_RED_LED, LED_ON);
 		delay(50);
 		digitalWrite(Pin_RED_LED, LED_OFF);

--- a/Sketches/libraries/EPD_FLASH/EPD_FLASH.cpp
+++ b/Sketches/libraries/EPD_FLASH/EPD_FLASH.cpp
@@ -60,7 +60,7 @@ enum {
 EPD_FLASH_Class EPD_FLASH(9);
 
 
-EPD_FLASH_Class::EPD_FLASH_Class(uint8_t chip_select_pin) : CS(chip_select_pin) {
+EPD_FLASH_Class::EPD_FLASH_Class(uint8_t chip_select_pin) : EPD_FLASH_CS(chip_select_pin) {
 }
 
 
@@ -68,7 +68,7 @@ EPD_FLASH_Class::EPD_FLASH_Class(uint8_t chip_select_pin) : CS(chip_select_pin) 
 void EPD_FLASH_Class::begin(uint8_t chip_select_pin) {
 	digitalWrite(chip_select_pin, HIGH);
 	pinMode(chip_select_pin, OUTPUT);
-	this->CS = chip_select_pin;
+	this->EPD_FLASH_CS = chip_select_pin;
 }
 
 
@@ -78,7 +78,7 @@ void EPD_FLASH_Class::end(void) {
 // configure the SPI for EPD_FLASH access
 void EPD_FLASH_Class::spi_setup(void) {
 	SPI.begin();
-	digitalWrite(this->CS, HIGH);
+	digitalWrite(this->EPD_FLASH_CS, HIGH);
 
 	SPI.setBitOrder(MSBFIRST);
 	SPI.setDataMode(SPI_MODE3);
@@ -95,7 +95,7 @@ void EPD_FLASH_Class::spi_setup(void) {
 // shutdown SPI after EPD_FLASH access
 void EPD_FLASH_Class::spi_teardown(void) {
 	Delay_us(10);
-	digitalWrite(this->CS, HIGH);
+	digitalWrite(this->EPD_FLASH_CS, HIGH);
 	SPI.transfer(EPD_FLASH_NOP); // flush the SPI buffer
 	SPI.end();
 }
@@ -114,11 +114,11 @@ bool EPD_FLASH_Class::available(void) {
 void EPD_FLASH_Class::info(uint8_t *maufacturer, uint16_t *device) {
 	this->wait_for_ready();
 
-	digitalWrite(this->CS, LOW);
+	digitalWrite(this->EPD_FLASH_CS, LOW);
 	Delay_us(1500);                     // FLASH wake up delay
-	digitalWrite(this->CS, HIGH);
+	digitalWrite(this->EPD_FLASH_CS, HIGH);
 	Delay_us(50);
-	digitalWrite(this->CS, LOW);
+	digitalWrite(this->EPD_FLASH_CS, LOW);
 	Delay_us(10);
 	SPI.transfer(EPD_FLASH_RDID);
 	*maufacturer = SPI.transfer(EPD_FLASH_NOP);
@@ -132,7 +132,7 @@ void EPD_FLASH_Class::info(uint8_t *maufacturer, uint16_t *device) {
 void EPD_FLASH_Class::read(void *buffer, uint32_t address, uint16_t length) {
 	this->wait_for_ready();
 
-	digitalWrite(this->CS, LOW);
+	digitalWrite(this->EPD_FLASH_CS, LOW);
 	Delay_us(10);
 	SPI.transfer(EPD_FLASH_FAST_READ);
 	SPI.transfer(address >> 16);
@@ -153,11 +153,11 @@ void EPD_FLASH_Class::wait_for_ready(void) {
 }
 
 bool EPD_FLASH_Class::is_busy(void) {
-	digitalWrite(this->CS, LOW);
+	digitalWrite(this->EPD_FLASH_CS, LOW);
 	Delay_us(10);
 	SPI.transfer(EPD_FLASH_RDSR);
 	bool busy = 0 != (EPD_FLASH_WIP & SPI.transfer(EPD_FLASH_NOP));
-	digitalWrite(this->CS, HIGH);
+	digitalWrite(this->EPD_FLASH_CS, HIGH);
 	SPI.transfer(EPD_FLASH_NOP);
 	Delay_us(10);
 	return busy;
@@ -167,7 +167,7 @@ bool EPD_FLASH_Class::is_busy(void) {
 void EPD_FLASH_Class::write_enable(void) {
 	this->wait_for_ready();
 
-	digitalWrite(this->CS, LOW);
+	digitalWrite(this->EPD_FLASH_CS, LOW);
 	Delay_us(10);
 	SPI.transfer(EPD_FLASH_WREN);
 	this->spi_teardown();
@@ -178,7 +178,7 @@ void EPD_FLASH_Class::write_enable(void) {
 void EPD_FLASH_Class::write_disable(void) {
 	this->wait_for_ready();
 
-	digitalWrite(this->CS, LOW);
+	digitalWrite(this->EPD_FLASH_CS, LOW);
 	Delay_us(10);
 	SPI.transfer(EPD_FLASH_WRDI);
 	this->spi_teardown();
@@ -188,7 +188,7 @@ void EPD_FLASH_Class::write_disable(void) {
 void EPD_FLASH_Class::write(uint32_t address, const void *buffer, uint16_t length) {
 	this->wait_for_ready();
 
-	digitalWrite(this->CS, LOW);
+	digitalWrite(this->EPD_FLASH_CS, LOW);
 	Delay_us(10);
 	SPI.transfer(EPD_FLASH_PP);
 	SPI.transfer(address >> 16);
@@ -205,7 +205,7 @@ void EPD_FLASH_Class::write(uint32_t address, const void *buffer, uint16_t lengt
 void EPD_FLASH_Class::write_from_progmem(uint32_t address, PROGMEM const void *buffer, uint16_t length) {
 	this->wait_for_ready();
 
-	digitalWrite(this->CS, LOW);
+	digitalWrite(this->EPD_FLASH_CS, LOW);
 	Delay_us(10);
 	SPI.transfer(EPD_FLASH_PP);
 	SPI.transfer(address >> 16);
@@ -223,7 +223,7 @@ void EPD_FLASH_Class::write_from_progmem(uint32_t address, PROGMEM const void *b
 void EPD_FLASH_Class::sector_erase(uint32_t address) {
 	this->wait_for_ready();
 
-	digitalWrite(this->CS, LOW);
+	digitalWrite(this->EPD_FLASH_CS, LOW);
 	Delay_us(10);
 	SPI.transfer(EPD_FLASH_SE);
 	SPI.transfer(address >> 16);

--- a/Sketches/libraries/EPD_FLASH/EPD_FLASH.cpp
+++ b/Sketches/libraries/EPD_FLASH/EPD_FLASH.cpp
@@ -12,8 +12,11 @@
 // express or implied.  See the License for the specific language
 // governing permissions and limitations under the License.
 
+// Updated 2015-08-01 by Rei Vilo
+// . Added #include Energia
+// . Changed CS for EPD_FLASH_CS to avoid conflicts with Energia
 
-#include <Arduino.h>
+//#include <Arduino.h>
 
 #include <SPI.h>
 

--- a/Sketches/libraries/EPD_FLASH/EPD_FLASH.h
+++ b/Sketches/libraries/EPD_FLASH/EPD_FLASH.h
@@ -13,7 +13,8 @@
 // governing permissions and limitations under the License.
 
 // Updated 2015-08-01 by Rei Vilo
-// Changed CS for EPD_FLASH_CS to avoid conflicts with Energia
+// . Added #include Energia
+// . Changed CS for EPD_FLASH_CS to avoid conflicts with Energia
 
 #if !defined(EPD_FLASH_H)
 #define EPD_FLASH_H 1

--- a/Sketches/libraries/EPD_FLASH/EPD_FLASH.h
+++ b/Sketches/libraries/EPD_FLASH/EPD_FLASH.h
@@ -12,10 +12,17 @@
 // express or implied.  See the License for the specific language
 // governing permissions and limitations under the License.
 
+// Updated 2015-08-01 by Rei Vilo
+// Changed CS for EPD_FLASH_CS to avoid conflicts with Energia
+
 #if !defined(EPD_FLASH_H)
 #define EPD_FLASH_H 1
 
-#include <Arduino.h>
+#if defined(ENERGIA)
+#   include "Energia.h"
+#else
+#   include <Arduino.h>
+#endif
 
 
 // maximum bytes that can be written by one write command
@@ -33,7 +40,7 @@
 
 class EPD_FLASH_Class {
 private:
-	uint8_t CS;
+	uint8_t EPD_FLASH_CS;
 
 	void spi_setup(void);
 	void spi_teardown(void);

--- a/Sketches/libraries/EPD_V231_G2/EPD_V231_G2.h
+++ b/Sketches/libraries/EPD_V231_G2/EPD_V231_G2.h
@@ -12,10 +12,18 @@
 // express or implied.  See the License for the specific language
 // governing permissions and limitations under the License.
 
+// Updated 2015-08-01 by Rei Vilo
+// . Added #include Energia
+
 #if !defined(EPD_V231_G2_H)
 #define EPD_V231_G2_H 1
 
-#include <Arduino.h>
+#if defined(ENERGIA)
+#   include "Energia.h"
+#else
+#   include <Arduino.h>
+#endif
+
 #include <SPI.h>
 
 #if defined(__AVR__)

--- a/Sketches/libraries/S5813A/S5813A.cpp
+++ b/Sketches/libraries/S5813A/S5813A.cpp
@@ -12,16 +12,21 @@
 // express or implied.  See the License for the specific language
 // governing permissions and limitations under the License.
 
+// Updated 2015-08-01 by Rei Vilo
+// . Added #include Energia
+// . Changed uV to mV to avoid overflows
 
-#include <Arduino.h>
+//#include <Arduino.h>
 
 #include "S5813A.h"
 
 
-#if defined(__MSP430_CPU__)
+//#if defined(__MSP430_CPU__)
 
 // TI LaunchPad defaults
 // ---------------------
+#if defined(__MSP430G2553__)
+#warning __MSP430G2553__ for ADC_COUNTS
 
 // LaunchPad / TI MSP430G2553 runs at 3.3V .. 3.5V
 #define PIN_TEMPERATURE  A4
@@ -31,7 +36,50 @@
 
 // ADC maximum voltage at counts
 #define ADC_MAXIMUM_uV   2500000L
+#define ADC_MAXIMUM_mV   2500L
 #define ADC_COUNTS       1024L
+
+#elif defined(__MSP432P401R__)
+#warning __MSP432P401R__ for ADC_COUNTS
+
+#define PIN_TEMPERATURE  6
+
+// ADC maximum voltage at counts
+#define ADC_MAXIMUM_uV   3300000L
+#define ADC_MAXIMUM_mV   3300L
+#define ADC_COUNTS       1024L
+
+#elif defined(__MSP430F5529__)
+#warning __MSP430F5529__ for ADC_COUNTS
+
+#define PIN_TEMPERATURE  6
+
+// ADC maximum voltage at counts
+#define ADC_MAXIMUM_uV   3300000L
+#define ADC_MAXIMUM_mV   3300L
+#define ADC_COUNTS       4096L
+
+#elif defined(__LM4F120H5QR__)
+#warning __LM4F120H5QR__ for ADC_COUNTS
+
+#define PIN_TEMPERATURE  6
+
+// ADC maximum voltage at counts
+#define ADC_MAXIMUM_uV   3300000L
+#define ADC_MAXIMUM_mV   3300L
+#define ADC_COUNTS       4096L
+
+#elif defined(__CC3200R1M1RGC__)
+#warning __CC3200R1M1RGC__ for ADC_COUNTS
+
+#define PIN_TEMPERATURE  6
+
+// ADC maximum voltage at counts
+// See SWAS032E –JULY 2013–REVISED JUNE 2014
+// § 3.2 Drive Strength and Reset States for Analog-Digital Multiplexed Pins
+#define ADC_MAXIMUM_uV   1460000L
+#define ADC_MAXIMUM_mV   1460L
+#define ADC_COUNTS       4096L
 
 #else
 
@@ -46,6 +94,7 @@
 
 // ADC maximum voltage at counts
 #define ADC_MAXIMUM_uV   5000000L
+#define ADC_MAXIMUM_mV   5000L
 #define ADC_COUNTS       1024L
 
 #endif
@@ -57,6 +106,9 @@
 #define Vstart_uV 1145000L
 #define Tstart_C  100
 #define Vslope_uV -11040L
+
+#define Vstart_mV 1145L
+#define Vslope_mV -11
 
 
 // there is a potential divider on the input, so as scale to the
@@ -78,9 +130,12 @@ S5813A_Class::S5813A_Class(uint8_t input_pin) : temperature_pin(input_pin) {
 
 
 // initialise the analog system
-void S5813A_Class::begin(uint8_t input_pin) {
+void S5813A_Class::begin(uint8_t input_pin)
+{
 	pinMode(input_pin, INPUT);
+#if defined(__MSP430G2553__)
 	analogReference(ANALOG_REFERENCE);
+#endif
 	this->temperature_pin = input_pin;
 }
 
@@ -92,13 +147,29 @@ void S5813A_Class::end(void) {
 // return sensor output voltage in uV
 // not the ADC value, but the value that should be measured on the
 // sensor output pin
-long S5813A_Class::readVoltage(void) {
+long S5813A_Class::readVoltage(void)
+{
 	long vADC = analogRead(this->temperature_pin);
-	return REV_PD((vADC * ADC_MAXIMUM_uV) / ADC_COUNTS);
+/*
+    Serial.print("analogRead=");
+    Serial.print(vADC);
+    Serial.print("\treadVoltage=");
+    Serial.println(REV_PD((vADC * ADC_MAXIMUM_mV) / ADC_COUNTS));
+ */
+	return REV_PD((vADC * ADC_MAXIMUM_mV) / ADC_COUNTS);
 }
 
 
-// return temperature as integer in Celcius
-int S5813A_Class::read(void) {
-	return Tstart_C + ((this->readVoltage() - Vstart_uV) / Vslope_uV);
+// return temperature as integer in Celsius
+int S5813A_Class::read(void)
+{
+    long vADC = this->readVoltage();
+    int result = Tstart_C + (1.0 * vADC - Vstart_mV) / Vslope_mV;
+/*
+    Serial.print("vADC=");
+    Serial.print(vADC, DEC);
+    Serial.print("\tresult=");
+    Serial.println(result, DEC);
+*/
+    return result;
 }

--- a/Sketches/libraries/S5813A/S5813A.h
+++ b/Sketches/libraries/S5813A/S5813A.h
@@ -12,10 +12,18 @@
 // express or implied.  See the License for the specific language
 // governing permissions and limitations under the License.
 
+// Updated 2015-08-01 by Rei Vilo
+// . Added #include Energia
+// . Changed uV to mV to avoid overflows
+
 #if !defined(EPD_S5813A_H)
 #define EPD_S5813A_H 1
 
-#include <Arduino.h>
+#if defined(ENERGIA)
+#   include "Energia.h"
+#else
+#   include <Arduino.h>
+#endif
 
 // TODO: Why is begin allowed to change the temperature pin(?)
 // Except for that could make temperature_pin a const


### PR DESCRIPTION
### Results
 + Works on MSP430F5529, LM4F120, TM4C123, TM4C129
 + Fails on MSP432 and CC3200

### Changes
* All: Added #include Energia
* Main: For Energia, changed pin names to pin numbers (see comment below)
* S5813A: Changed uV to mV to avoid overflows
* EPD_FLASH: Changed CS for EPD_FLASH_CS to avoid conflicts with Energia
