### PR TITLE
Using `tobytes()` instead of deprecated `tostring()`

### DIFF
--- a/PlatformWithOS/demo/EPD.py
+++ b/PlatformWithOS/demo/EPD.py
@@ -136,7 +136,7 @@ to use:
             raise EPDError('image size mismatch')
 
         with open(os.path.join(self._epd_path, 'LE', 'display_inverse'), 'r+b') as f:
-            f.write(image.tostring())
+            f.write(image.tobytes())
 
         if self.auto:
             self.update()


### PR DESCRIPTION
Simply trying on ArchLinux the counter command there is an error:
```
$ python2 demo/CounterDemo.py 3 20
panel = EPD 2.0 200 x 96  version=4 COG=2 FILM=231
Traceback (most recent call last):
  File "demo/CounterDemo.py", line 99, in <module>
    main(sys.argv[1:])
  File "demo/CounterDemo.py", line 67, in main
    demo(epd, start)
  File "demo/CounterDemo.py", line 90, in demo
    epd.display(image)
  File "/home/sinon/gratis/PlatformWithOS/demo/EPD.py", line 139, in display
    f.write(image.tostring())
  File "/usr/lib/python2.7/site-packages/PIL/Image.py", line 686, in tostring
    "Please call tobytes() instead.")
Exception: tostring() has been removed. Please call tobytes() instead.
```
The error appears in every demo but with this change it disappears and works without problems.