### PR TITLE
Fix partial update in epd-fuse

### DIFF
--- a/PlatformWithOS/driver-common/V231_G2/epd.c
+++ b/PlatformWithOS/driver-common/V231_G2/epd.c
@@ -517,7 +517,7 @@ void EPD_image(EPD_type *epd, const uint8_t *old_image, const uint8_t *new_image
 // change from old image to new image
 void EPD_partial_image(EPD_type *epd, const uint8_t *old_image, const uint8_t *new_image) {
 	// Only need last stage for partial update
-	// See discussion on issue #13 in the repaper/gratis repository on github
+	// See discussion on issue #19 in the repaper/gratis repository on github
 	frame_data_repeat(epd, new_image, old_image, EPD_normal);
 }
 

--- a/PlatformWithOS/driver-common/epd_fuse.c
+++ b/PlatformWithOS/driver-common/epd_fuse.c
@@ -607,7 +607,11 @@ static void run_command(const char c) {
 #else
 #error "unsupported EPD_image() function"
 #endif
+
+#ifndef EPD_PARTIAL_AVAILABLE
+		// Do not switch off COG when doing a partial update.
 		EPD_end(epd);
+#endif
 
 		memcpy(current_buffer, display_buffer, sizeof(display_buffer));
 		break;

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ in the discussion of issue #13 on the repaper/gratis github repository.
 
 The original code in epd_fuse.c and V231G2/epd.c under PlatformWithOS did a full 4 cycle display update
 including COG power on and COG power down sequence.
-This resulted in the update taking more than 3 seconds with the display frist showing the updated image,
+This resulted in the update taking more than 3 seconds with the display first showing the updated image,
 then the original image followed finally by the updated image.
 This made things like a clock, counters and 'game of life' look very bad.
 
 Following changes as outlined in issue #13:
-* in epd_fuse.c run_command do not call EPD_end() at the end of the 'P' command (only if partial update is supported by the display)
+* in epd_fuse.c run_command() do not call EPD_end() at the end of the 'P' command (only if partial update is supported by the display)
 * in epd.c introduce COG_on status variable in EPD_struct.
 * in epd.c EPD_begin() return immediately when COG_on is true
-* in epd.C EPR_begin() set COG_on to true at the end of the function.
+* in epd.C EPD_begin() set COG_on to true at the end of the function.
 * in epd.c EPD_end() set COG_on to false at the end of the function.
 * in epd.c EPD_partial_image() only call the last stage (EPD_normal).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,26 @@
 # gratis
+## Branch notes
+
+This branch implements a proper partial update following the algorithm outlined
+in the discussion of issue #13 on the repaper/gratis github repository.
+
+The original code in epd_fuse.c and V231G2/epd.c under PlatformWithOS did a full 4 cycle display update
+including COG power on and COG power down sequence.
+This resulted in the update taking more than 3 seconds with the display frist showing the updated image,
+then the original image followed finally by the updated image.
+This made things like a clock, counters and 'game of life' look very bad.
+
+Following changes as outlined in issue #13:
+* in epd_fuse.c run_command do not call EPD_end() at the end of the 'P' command (only if partial update is supported by the display)
+* in epd.c introduce COG_on status variable in EPD_struct.
+* in epd.c EPD_begin() return immediately when COG_on is true
+* in epd.C EPR_begin() set COG_on to true at the end of the function.
+* in epd.c EPD_end() set COG_on to false at the end of the function.
+* in epd.c EPD_partial_image() only call the last stage (EPD_normal).
+
+With these changes you can get a proper partial display update frequency < 1 Hz.
+
+## Original README below
 
 Updated 2015-08-01 by Rei Vilo
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Branch notes
 
 This branch implements a proper partial update following the algorithm outlined
-in the discussion of issue #13 on the repaper/gratis github repository.
+in the discussion of issue #19 on the repaper/gratis github repository.
 
 The original code in epd_fuse.c and V231G2/epd.c under PlatformWithOS did a full 4 cycle display update
 including COG power on and COG power down sequence.
@@ -14,11 +14,15 @@ Following changes as outlined in issue #13:
 * in epd_fuse.c run_command() do not call EPD_end() at the end of the 'P' command (only if partial update is supported by the display)
 * in epd.c introduce COG_on status variable in EPD_struct.
 * in epd.c EPD_begin() return immediately when COG_on is true
-* in epd.C EPD_begin() set COG_on to true at the end of the function.
+* in epd.c EPD_begin() set COG_on to true at the end of the function.
 * in epd.c EPD_end() set COG_on to false at the end of the function.
 * in epd.c EPD_partial_image() only call the last stage (EPD_normal).
 
 With these changes you can get a proper partial display update frequency < 1 Hz.
+
+For a YouTube video showing the difference between before and after the fix see https://youtu.be/dciaFRKtetU
+
+<a href="http://www.youtube.com/watch?feature=player_embedded&v=dciaFRKtetU" target="_blank"><img src="http://img.youtube.com/vi/dciaFRKtetU/0.jpg" alt="IMAGE ALT TEXT HERE" width="240" height="180" border="10" /></a>
 
 ## Original README below
 


### PR DESCRIPTION
Issue #19 has a description for a proper partial update.
I implemented this in epd-fuse and now get a real partial update with frequency > 1Hz. You can get up to 2 Hz by reducing the stage-time from 630ms to e.g. 490ms for the 2.7 inch display.
See the video on YouTube https://t.co/tYGdGizrjb for a demo.