### PR TITLE
Add '/n' to /dev/epd/error output

### DIFF
--- a/PlatformWithOS/driver-common/epd_fuse.c
+++ b/PlatformWithOS/driver-common/epd_fuse.c
@@ -95,11 +95,11 @@ static const struct panel_struct {
 };
 
 static const char *error_texts[] = {
-  "OK",               // EPD_OK
-  "Unsupported COG",  // EPD_UNSUPPORTED_COG
-  "Panel broken",     // EPD_PANEL_BROKEN
-  "DC Failed",        // EPD_DC_FAILED
-  "Undefined"         // EPD_UNDEFINED
+  "OK\n",               // EPD_OK
+  "Unsupported COG\n",  // EPD_UNSUPPORTED_COG
+  "Panel broken\n",     // EPD_PANEL_BROKEN
+  "DC Failed\n",        // EPD_DC_FAILED
+  "Undefined\n"         // EPD_UNDEFINED
 };
 
 // need to sync size with above (max of all sizes)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gratis
-## Branch notes
+## Partial Update implementation notes, February 2016
 
 This branch implements a proper partial update following the algorithm outlined
 in the discussion of issue #19 on the repaper/gratis github repository.
@@ -24,7 +24,7 @@ For a YouTube video showing the difference between before and after the fix see 
 
 <a href="http://www.youtube.com/watch?feature=player_embedded&v=dciaFRKtetU" target="_blank"><img src="http://img.youtube.com/vi/dciaFRKtetU/0.jpg" alt="IMAGE ALT TEXT HERE" width="240" height="180" border="10" /></a>
 
-## Original README below
+## Notes for Energia support, August 2015
 
 Updated 2015-08-01 by Rei Vilo
 


### PR DESCRIPTION
Added a linefeed to all error definition texts (output of cat '/dev/epd/error').
Minor edits to heading in main README.