### PR TITLE
Corrected dh-systemd service file handling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+epd-fuse (0.1.2) unstable; urgency=low
+
+  * Improved systemd service file handling
+
+ -- EngSaS - Joachim Langenbach <info@engsas.de>  Fri, 21 Apr 2017 13:50:00 +0200
+
 epd-fuse (0.1.1) unstable; urgency=low
 
   * Switched python packages to architecture all instead of any

--- a/debian/epd-fuse-v230-g2.install
+++ b/debian/epd-fuse-v230-g2.install
@@ -1,0 +1,1 @@
+debian/epd-fuse-v230-g2/usr/lib/systemd/system/epd-fuse.service lib/systemd/system/


### PR DESCRIPTION
The service file must be installed to /lib/systemd/system within debian packages. The path is adjusted in epd-fuse-v230-g2.install. With the adjusted path, dh-systemd automatically adds postinst, prerm and postrm scripts to the package to handle the installed service file correctly.