### PR TITLE
support added for ESP32 and Teensy 3.1/3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,33 @@
 # gratis
+
+## Notes for mrwastl/gratis-branch
+
+This branch adds basic support for Teensy 3.1/3.2 and ESP32.
+
+### Teensy 3.1/3.2
+Default IO layout is defined in EPD_PINOUT/EPD_PINOUT_Teensy.h.
+
+Pin numbers can be assigned individually when calling the constructor.
+
+### ESP32
+Default IO layout is defined in EPD_PINOUT/EPD_PINOUT_ESP32.h.
+
+Pin numbers and PWM channel ID (EPD_V110_G1 only) can be assigned individually when calling the constructor.
+
+SPI channel ID and SPI pin numbers can only be changed in EPD_PINOUT_ESP32.h, a more flexible handling would require
+some API changes.
+
+
+### Tests
+
+As I just own an EPD_V110_G1 module (2.7") I can only test this one. All other combinations are tested if compilation is successful.
+
+
+
+
+
+## Original README of repaper/gratis-branch below
+
 ## Partial Update implementation notes, February 2016
 
 This branch implements a proper partial update following the algorithm outlined

--- a/Sketches/libraries/EPD_PINOUT/EPD_PINOUT.h
+++ b/Sketches/libraries/EPD_PINOUT/EPD_PINOUT.h
@@ -17,7 +17,9 @@
 
 #include <EPD_PANELS.h>
 
-#if defined(ENERGIA)
+#if defined(CORE_TEENSY)
+#include <EPD_PINOUT_Teensy.h>
+#elif defined(ENERGIA)
 #include <EPD_PINOUT_Energia.h>
 #else
 #include <EPD_PINOUT_Arduino.h>

--- a/Sketches/libraries/EPD_PINOUT/EPD_PINOUT.h
+++ b/Sketches/libraries/EPD_PINOUT/EPD_PINOUT.h
@@ -1,4 +1,5 @@
 // Copyright 2013-2015 Pervasive Displays, Inc.
+// Copyright 2016-2017 Wolfgang Astleitner (mrwastl@users.sourceforge.net)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +20,8 @@
 
 #if defined(CORE_TEENSY)
 #include <EPD_PINOUT_Teensy.h>
+#elif defined(ESP32)
+#include <EPD_PINOUT_ESP32.h>
 #elif defined(ENERGIA)
 #include <EPD_PINOUT_Energia.h>
 #else

--- a/Sketches/libraries/EPD_PINOUT/EPD_PINOUT_ESP32.h
+++ b/Sketches/libraries/EPD_PINOUT/EPD_PINOUT_ESP32.h
@@ -1,0 +1,51 @@
+// Copyright 2013-2015 Pervasive Displays, Inc.
+// Copyright 2017 Wolfgang Astleitner (mrwastl@users.sourceforge.net)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied.  See the License for the specific language
+// governing permissions and limitations under the License.
+
+#if !defined(EPD_PINOUT_ESP32_H)
+#define EPD_PINOUT_ESP32_H 1
+
+// ESP32 IO layout
+const int Pin_TEMPERATURE  = A6 /* A6 == 34 */;
+const int Pin_PANEL_ON     = 21;
+const int Pin_BORDER       = 27;
+const int Pin_DISCHARGE    = 22;
+const int Pin_RESET        = 25;
+const int Pin_BUSY         = 33;
+const int Pin_EPD_CS       = 32;
+const int Pin_EPD_FLASH_CS = 17;
+
+// PWM: for V110 only
+const int Pin_PWM          = 26;
+const int Pin_PWM_Channel  = 0;
+
+// customisable SPI
+const int Pin_SPI_MISO     = 12;
+const int Pin_SPI_MOSI     = 13;
+const int Pin_SPI_SCK      = 14;
+const int Pin_SPI_Channel  = 2;
+// set SPI frequency to 40 MHz (max. freq. for COG driver)
+// will be reduced to 20 MHz because of SPI_CLOCK_DIV2 (see SPI_on())
+const uint32_t ESP32_SPI_Frequency = 40000000;
+
+
+// the following are defined for completeness but not used or required
+//   for driving the display
+const int Pin_SW2 = 2;
+const int Pin_RED_LED = 4;
+
+// SPI object for both EPD_FLASH and EPD_V???_G?-classes
+static SPIClass esp32_spi(Pin_SPI_Channel);
+
+#endif

--- a/Sketches/libraries/EPD_PINOUT/EPD_PINOUT_Teensy.h
+++ b/Sketches/libraries/EPD_PINOUT/EPD_PINOUT_Teensy.h
@@ -1,0 +1,38 @@
+// Copyright 2013-2015 Pervasive Displays, Inc.
+// Copyright 2016 Wolfgang Astleitner (mrwastl@users.sourceforge.net)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied.  See the License for the specific language
+// governing permissions and limitations under the License.
+
+#if !defined(EPD_PINOUT_TEENSY_H)
+#define EPD_PINOUT_TEENSY_H 1
+
+// pinout is taken from:
+//   https://forum.pjrc.com/threads/25793-2-7-inch-ePaper-on-Teensy-does-not-compile-Adafruit_GFX#post53636
+
+// Teensy 3.x IO layout
+const int Pin_TEMPERATURE = A0;
+const int Pin_PANEL_ON = 2;
+const int Pin_BORDER = 3;
+const int Pin_DISCHARGE = 4;
+const int Pin_PWM = 5;
+const int Pin_RESET = 6;
+const int Pin_BUSY = 7;
+const int Pin_EPD_CS = 8;
+const int Pin_EPD_FLASH_CS = 9;
+
+// the following are defined for completeness but not used or required
+//   for driving the display
+const int Pin_SW2 = 0;
+const int Pin_RED_LED = 1;
+
+#endif

--- a/Sketches/libraries/EPD_PINOUT/EPD_PINOUT_Teensy.h
+++ b/Sketches/libraries/EPD_PINOUT/EPD_PINOUT_Teensy.h
@@ -1,5 +1,5 @@
 // Copyright 2013-2015 Pervasive Displays, Inc.
-// Copyright 2016 Wolfgang Astleitner (mrwastl@users.sourceforge.net)
+// Copyright 2016-2017 Wolfgang Astleitner (mrwastl@users.sourceforge.net)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 // pinout is taken from:
 //   https://forum.pjrc.com/threads/25793-2-7-inch-ePaper-on-Teensy-does-not-compile-Adafruit_GFX#post53636
 
-// Teensy 3.x IO layout
+// Teensy 3.1/3.2 IO layout
 const int Pin_TEMPERATURE = A0;
 const int Pin_PANEL_ON = 2;
 const int Pin_BORDER = 3;

--- a/Sketches/libraries/EPD_V110_G1/EPD_V110_G1.h
+++ b/Sketches/libraries/EPD_V110_G1/EPD_V110_G1.h
@@ -43,7 +43,7 @@
 
 
 // if more SRAM available (8 kBytes)
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_TEENSY)
 #define EPD_ENABLE_EXTRA_SRAM 1
 #endif
 

--- a/Sketches/libraries/EPD_V110_G1/EPD_V110_G1.h
+++ b/Sketches/libraries/EPD_V110_G1/EPD_V110_G1.h
@@ -43,7 +43,7 @@
 
 
 // if more SRAM available (8 kBytes)
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_TEENSY)
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_TEENSY) || defined (ESP32)
 #define EPD_ENABLE_EXTRA_SRAM 1
 #endif
 
@@ -94,6 +94,10 @@ private:
 	bool filler;
 
 	EPD_Class(const EPD_Class &f);  // prevent copy
+
+#ifdef ESP32
+	const uint8_t EPD_Channel_PWM;
+#endif
 
 public:
 	// power up and power down the EPD panel
@@ -174,7 +178,6 @@ public:
 	// single line display - very low-level
 	// also has to handle AVR progmem
 	void line(uint16_t line, const uint8_t *data, uint8_t fixed_value, bool read_progmem, EPD_stage stage);
-
 	// inline static void attachInterrupt();
 	// inline static void detachInterrupt();
 
@@ -185,7 +188,11 @@ public:
 		  uint8_t pwm_pin,
 		  uint8_t reset_pin,
 		  uint8_t busy_pin,
-		  uint8_t chip_select_pin);
+		  uint8_t chip_select_pin
+#ifdef ESP32
+		 ,uint8_t pwm_channel = 0
+#endif
+	);
 
 };
 

--- a/Sketches/libraries/EPD_V230_G2/EPD_V230_G2.cpp
+++ b/Sketches/libraries/EPD_V230_G2/EPD_V230_G2.cpp
@@ -1,5 +1,8 @@
 // Copyright 2013-2015 Pervasive Displays, Inc.
 //
+// Teensy 3.1/3.2 and ESP32 adaptions:
+//   Copyright 2016-2017 Wolfgang Astleitner (mrwastl@serdisplib.sf.net)
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:
@@ -32,6 +35,13 @@
 #define BORDER_BYTE_BLACK 0xff
 #define BORDER_BYTE_WHITE 0xaa
 #define BORDER_BYTE_NULL  0x00
+
+#ifndef ESP32
+	#define SPI_OBJECT  SPI
+#else
+	#include "EPD_PINOUT_ESP32.h"
+	#define SPI_OBJECT  esp32_spi
+#endif
 
 static void SPI_on(void);
 static void SPI_off(void);
@@ -101,6 +111,10 @@ EPD_Class::EPD_Class(EPD_size _size,
 	}
 	}
 
+#if defined (ESP32)
+	// set SPI frequency (defined in EPD_PINOUT_ESP32.h)
+	SPI_OBJECT.setFrequency(ESP32_SPI_Frequency);
+#endif
 }
 
 
@@ -683,11 +697,15 @@ void EPD_Class::line(uint16_t line, const uint8_t *data, uint8_t fixed_value,
 
 
 static void SPI_on(void) {
-	SPI.end();
-	SPI.begin();
-	SPI.setBitOrder(MSBFIRST);
-	SPI.setDataMode(SPI_MODE0);
-	SPI.setClockDivider(SPI_CLOCK_DIV2);
+	SPI_OBJECT.end();
+#ifndef ESP32
+	SPI_OBJECT.begin();
+#else
+	SPI_OBJECT.begin(Pin_SPI_SCK, Pin_SPI_MISO, Pin_SPI_MOSI);
+#endif
+	SPI_OBJECT.setBitOrder(MSBFIRST);
+	SPI_OBJECT.setDataMode(SPI_MODE0);
+	SPI_OBJECT.setClockDivider(SPI_CLOCK_DIV2);
 	SPI_put(0x00);
 	SPI_put(0x00);
 	Delay_us(10);
@@ -697,17 +715,17 @@ static void SPI_on(void) {
 static void SPI_off(void) {
 	// SPI.begin();
 	// SPI.setBitOrder(MSBFIRST);
-	SPI.setDataMode(SPI_MODE0);
+	SPI_OBJECT.setDataMode(SPI_MODE0);
 	// SPI.setClockDivider(SPI_CLOCK_DIV2);
 	SPI_put(0x00);
 	SPI_put(0x00);
 	Delay_us(10);
-	SPI.end();
+	SPI_OBJECT.end();
 }
 
 
 static void SPI_put(uint8_t c) {
-	SPI.transfer(c);
+	SPI_OBJECT.transfer(c);
 }
 
 
@@ -734,7 +752,7 @@ static uint8_t SPI_read(uint8_t cs_pin, const uint8_t *buffer, uint16_t length) 
 
 	// send all data
 	for (uint16_t i = 0; i < length; ++i) {
-		result = SPI.transfer(*buffer++);
+		result = SPI_OBJECT.transfer(*buffer++);
 		if (i < 4) {
 			rbuffer[i] = result;
 		}

--- a/Sketches/libraries/EPD_V230_G2/EPD_V230_G2.h
+++ b/Sketches/libraries/EPD_V230_G2/EPD_V230_G2.h
@@ -43,7 +43,7 @@
 
 
 // if more SRAM available (8 kBytes)
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_TEENSY) || defined (ESP32)
 #define EPD_ENABLE_EXTRA_SRAM 1
 #endif
 

--- a/Sketches/libraries/EPD_V231_G2/EPD_V231_G2.h
+++ b/Sketches/libraries/EPD_V231_G2/EPD_V231_G2.h
@@ -51,7 +51,7 @@
 
 
 // if more SRAM available (8 kBytes)
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(CORE_TEENSY) || defined (ESP32)
 #define EPD_ENABLE_EXTRA_SRAM 1
 #endif
 

--- a/Sketches/libraries/S5813A/S5813A.cpp
+++ b/Sketches/libraries/S5813A/S5813A.cpp
@@ -103,8 +103,8 @@
 #define ADC_MAXIMUM_mV   3300L
 #define ADC_COUNTS       1024L
 
-#elif defined(ARDUINO_ARCH_SAM)
-// Arduino Due runs at 3.3V
+#elif defined(ARDUINO_ARCH_SAM) || defined(CORE_TEENSY)
+// Arduino Due and Teensy run at 3.3V
 #define PIN_TEMPERATURE  A0
 
 #define ANALOG_REFERENCE DEFAULT

--- a/Sketches/libraries/S5813A/S5813A.cpp
+++ b/Sketches/libraries/S5813A/S5813A.cpp
@@ -19,6 +19,9 @@
 // Updated 18-04-2016 by Chiara Ruggeri (chiara@arduino.org)
 // . Added Arduino Due / Arduino M0 / Arduino Tian compatibility
 
+// Updated 2016-2017 by Wolfgang Astleitner (mrwastl@users.sourceforge.net)
+// . Added Teensy 3.1/3.2 and ESP32  compatibility
+
 #if defined(ENERGIA)
 #include <Energia.h>
 #else
@@ -114,6 +117,23 @@
 #define ADC_MAXIMUM_mV   3300L
 #define ADC_COUNTS       1024L
 
+#elif defined(ESP32)
+// ESP32 run at 3.3V, but measures from 0 to 3.6/3.9V (when using ADC_11db)
+#define PIN_TEMPERATURE  A6
+
+#define ANALOG_REFERENCE DEFAULT
+
+// ADC maximum voltage at counts
+// NOTA BENE: 4.1V-4.2V is to be determined empirically!
+// it is unclear, why this doesn't match the voltage range that would be expected when using ADC_11db)
+// tested with an ESP32 DevKitC : some value around 4.1
+// and a DOIT Devkit ESP32 V.1: some value around 4.2
+//#define ADC_MAXIMUM_uV   4100000L
+//#define ADC_MAXIMUM_mV   4100L
+#define ADC_MAXIMUM_uV   4200000L
+#define ADC_MAXIMUM_mV   4200L
+#define ADC_COUNTS       4096L
+
 #else
 // Arduino Leonardo / Atmel MEGA32U4 runs at 5V
 #define PIN_TEMPERATURE  A0
@@ -165,6 +185,10 @@ void S5813A_Class::begin(uint8_t input_pin)
 #if defined(__MSP430G2553__)
 	analogReference(ANALOG_REFERENCE);
 #endif
+#if defined(ESP32)
+	analogSetPinAttenuation(input_pin, ADC_11db);  /* 0 - 3.9V */
+	analogReadResolution(12); // matches ADC_COUNTS
+#endif
 	this->temperature_pin = input_pin;
 }
 
@@ -177,7 +201,32 @@ void S5813A_Class::end(void) {
 // not the ADC value, but the value that should be measured on the
 // sensor output pin
 long S5813A_Class::readVoltage(void) {
+#ifndef ESP32
 	long vADC = analogRead(this->temperature_pin);
+#else
+  // ESP32: analog reads are not very reliable: take 3 samples, determine 2 with shortest distance and average these
+  long vADC = 0.0;
+  long vADCser[3];
+  long vdiff01, vdiff02, vdiff12;
+  vADCser[0] = analogRead(this->temperature_pin);
+  vADCser[1] = analogRead(this->temperature_pin);
+  vADCser[2] = analogRead(this->temperature_pin);
+  // calculate absolute distances between all samples
+  vdiff01 = vADCser[0] - vADCser[1];  if (vdiff01 < 0.0) vdiff01 *= -1.0;
+  vdiff02 = vADCser[0] - vADCser[2];  if (vdiff02 < 0.0) vdiff02 *= -1.0;
+  vdiff12 = vADCser[1] - vADCser[2];  if (vdiff12 < 0.0) vdiff12 *= -1.0;
+  // find two samples with shortest distance and average these
+  if (vdiff01 < vdiff02) { // 0-1 < 0-2
+    vADC = (vdiff12 < vdiff01)  // 1-2 < 0-1 ?
+           ? (vADCser[1] + vADCser[2])  // shortest: 1-2
+           : (vADCser[0] + vADCser[1]); // shortest: 0-1
+  } else { // 0-2 < 0-1
+    vADC = (vdiff12 < vdiff02) // 1-2 < 0-2 ?
+           ? (vADCser[1] + vADCser[2])  // shortest: 1-2
+           : (vADCser[0] + vADCser[2]); // shortest: 0-2
+  }
+  vADC /= 2.0; // two values added together: calculate average
+#endif
 /*
     Serial.print("analogRead=");
     Serial.print(vADC);


### PR DESCRIPTION
my fork adds basic support for ESP32 and Teensy 3.1/3.2.

As I only own an EPD_V110_G1 module (2.7") I can only verify this one. All other combinations are tested if they compile successfully.