### PR TITLE
Avoid eps-fuse crash on Raspbian-Stretch

### DIFF
--- a/PlatformWithOS/driver-common/epd-fuse.service
+++ b/PlatformWithOS/driver-common/epd-fuse.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=A Fuse driver for the Repaper.org EPD
-After=network.target
+After=network.target dev-serial1.device
 
 [Service]
 Type=forking


### PR DESCRIPTION
On single core Pi versions without WiFi/Bluetooth hardware (Pi Zero,
B2, B+, …) epd-fuse initialisation can fail due to a race condition
between serial port and epd-fuse init. By waiting till after
/dev/serial1 init (which times out on these Pi versions) we make sure
epd-fuse init succeeds.