### PR TITLE
Avoid crash when spi not yet available

### DIFF
--- a/PlatformWithOS/driver-common/98-spidev.rules
+++ b/PlatformWithOS/driver-common/98-spidev.rules
@@ -1,0 +1,1 @@
+KERNEL=="spidev0.0", SUBSYSTEM=="spidev", TAG+="systemd"

--- a/PlatformWithOS/driver-common/Makefile
+++ b/PlatformWithOS/driver-common/Makefile
@@ -58,6 +58,8 @@ install: check-compiled
 ifeq (systemd,${SERVICE})
 	[ ! -d "${DESTDIR}${LIBDIR}/systemd/system" ] && mkdir -p "${DESTDIR}${LIBDIR}/systemd/system" || true
 	install --group=root --mode=644 --owner=root epd-fuse.service "${DESTDIR}${LIBDIR}/systemd/system/epd-fuse.service"
+	[ ! -d "${DESTDIR}${SYSCONFDIR}/udev/rules.d" ] && mkdir -p "${DESTDIR}${SYSCONFDIR}/udev/rules.d" || true
+	install --group=root --mode=644 --owner=root 98-spidev.rules "${DESTDIR}${SYSCONFDIR}/udev/rules.d/98-spidev.rules"
 else # otherwise Debian
 	if [ -e "${EPD_FUSE_CONF}" ] ; \
 	then \

--- a/PlatformWithOS/driver-common/epd-fuse.service
+++ b/PlatformWithOS/driver-common/epd-fuse.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=A Fuse driver for the Repaper.org EPD
-After=network.target dev-serial1.device
+After=network.target dev-serial1.device dev-spidev0.0.device
+BindsTo=dev-spidev0.0.device
 
 [Service]
 Type=forking


### PR DESCRIPTION
Under certain circumstances the spi device (/dev/spidev0.0) is not yet
available when epd-fuse starts. This resulted in not initialising the
epd structure and hence in a crash of epd-fuse at the first use.
Solved by letting udev signalling to systemd when spidev0.0 is made
available (file 98-spidev.rules in /etc/udev/rules.d) and modifying the
epd-fuse.service file to wait for /dev/spidev0.0