### PR TITLE
Fixes for Debian 11 Bullseye on RPi

### DIFF
--- a/PlatformWithOS/driver-common/Makefile
+++ b/PlatformWithOS/driver-common/Makefile
@@ -118,18 +118,17 @@ TEST_OBJECTS = epd_test.o ${DRIVER_OBJECTS}
 # build the fuse driver
 CLEAN_FILES += epd-fuse
 epd_fuse: ${FUSE_OBJECTS}
-	${CC} ${CFLAGS} ${LDFLAGS} -o "$@" ${FUSE_OBJECTS}
-
+	${CC} ${CFLAGS} -o "$@" ${FUSE_OBJECTS} ${LDFLAGS}
 
 # build simple GPIO test program
 CLEAN_FILES += gpio_test
 gpio_test: ${GPIO_OBJECTS}
-	${CC} ${CFLAGS} ${LDFLAGS} -o "$@" ${GPIO_OBJECTS}
+	${CC} ${CFLAGS} -o "$@" ${GPIO_OBJECTS} ${LDFLAGS}
 
 # build EPD test program
 CLEAN_FILES += epd_test
 epd_test: ${TEST_OBJECTS}
-	${CC} ${CFLAGS} ${LDFLAGS} -o "$@" ${TEST_OBJECTS}
+	${CC} ${CFLAGS} -o "$@" ${TEST_OBJECTS}a ${LDFLAGS}
 
 
 # dependencies


### PR DESCRIPTION
In Bullseye the bcm_host.h and libbcm_host.a are moved to the standard include and library directories. In Buster and older versions they were in a special directory tree /opt/vc.
Moving LDFLAGS to the end of the comman line makes it work on both Bullseye and Buster